### PR TITLE
Fix indexing bug in pathway helper

### DIFF
--- a/helpers.R
+++ b/helpers.R
@@ -5,7 +5,7 @@ df_to_signature <- function(df) {
     pathways <- unique(df[[1]])
     sig <- list()
     
-    for (i in seq_along(1:length(pathways))) {
+    for (i in seq_along(pathways)) {
         sig[[i]] <- df %>%
             filter(pathway == pathways[i]) %>%
             pull(gene)


### PR DESCRIPTION
## Summary
- avoid generating incorrect indices in `df_to_signature`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68827e5017ec8330a1c1a8481f505e58