### PR TITLE
Fix icon names for Shiny app

### DIFF
--- a/ui_design.R
+++ b/ui_design.R
@@ -11,9 +11,9 @@ button_cts_upload <- function() {
 }
 
 button_cts_process <- function() {
-    actionButton(inputId = "cts_process_click", 
-                 label = "2. Pre-Process Count and Metadata", 
-                 icon = icon("files-o"), 
+    actionButton(inputId = "cts_process_click",
+                 label = "2. Pre-Process Count and Metadata",
+                 icon = icon("file"),
                  class = "btn-upload")
 }
 
@@ -41,7 +41,7 @@ button_dge <- function() {
 button_read_gene <- function(value) {
     actionButton(inputId = paste0("rna_gene_read", as.character(value)),
                  label = "Plot",
-                 icon = icon("picture-o"),
+                 icon = icon("image"),
                  class = "btn-plot")
 }
 


### PR DESCRIPTION
## Summary
- update `button_cts_process()` and `button_read_gene()` to use valid Font Awesome icon names

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882aa1d1ad88330b7406894302bd782