### PR TITLE
Fix navbarPage header placement

### DIFF
--- a/app.R
+++ b/app.R
@@ -11,20 +11,20 @@ options(spinner.type = 8)
 
 # user interface
 ui <- navbarPage(
-    
+
     theme = shinytheme("yeti"),
     title = "Genomic Data Explorer",
     id = "tabs",
-    
+
+    header = tags$head(tags$link(rel = "stylesheet",
+                                 type = "text/css",
+                                 href = "style.css")),
+
     # tab_design.R
     tab_file,
     tab_rna,
     tab_help,
-    tab_about,
-    
-    tags$head(tags$link(rel = "stylesheet", 
-                        type = "text/css", 
-                        href = "style.css"))
+    tab_about
 )
 
 # server function


### PR DESCRIPTION
## Summary
- adjust navbarPage call to use `header` argument for style sheet link

## Testing
- `R -q -e "library(shiny)"` *(fails: there is no package called 'shiny')*

------
https://chatgpt.com/codex/tasks/task_e_6882ad2a622083309ec12b496d213b67