### PR TITLE
Fix example data paths for Shiny app

### DIFF
--- a/Rocker_GDE_base/install_packages.R
+++ b/Rocker_GDE_base/install_packages.R
@@ -2,7 +2,7 @@
 # Installed packages: shiny, tidyverse, devtools
 
 
-install.packages(c('magrittr','shinythemes','shinyWidgets','DT','RColorBrewer','circlize','scales','R.utils'), repos = 'http://cran.rstudio.com/')
+install.packages(c('magrittr','shinythemes','shinyWidgets','DT','RColorBrewer','circlize','scales','R.utils','here'), repos = 'http://cran.rstudio.com/')
 
 if (!requireNamespace("BiocManager", quietly = TRUE))
     install.packages("BiocManager")

--- a/app.R
+++ b/app.R
@@ -47,7 +47,7 @@ server <- function(input, output, session) {
     # Raw Data Input - Generation of Raw Counts and Metadata 
     mt_raw <- eventReactive(input$cts_upload_click, {
         if (input$cts_source == "Example") {
-            read_csv("./data/metadata.csv")
+            read_csv(here::here("data", "metadata.csv"))
         } else if (input$cts_source == "Upload") {
             validate(need(input$meta_file, "Please Upload Metadata"))
             read_csv(input$meta_file$datapath)
@@ -56,7 +56,7 @@ server <- function(input, output, session) {
     
     cts_raw <- eventReactive(input$cts_upload_click, {
         if (input$cts_source == "Example") {
-            readRDS("./data/example_mtx.rds")
+            readRDS(here::here("data", "example_mtx.rds"))
         } else if (input$cts_source == "Upload"){
             validate(need(input$cts_files, "Please Upload Count Data"))
             withProgress(message = "Loading Data..", value = 0.5, {

--- a/loading.R
+++ b/loading.R
@@ -6,6 +6,7 @@ packages <- c("shiny",
               "tidyverse", "magrittr","DT", 
               "RColorBrewer", "circlize", "ComplexHeatmap", "scales",
               "fgsea",
-              "xmcutil")
+              "xmcutil",
+              "here")
 
 lapply(packages, require, character.only = TRUE)


### PR DESCRIPTION
## Summary
- use `here` package so example data works regardless of working directory
- load the `here` package when the app starts
- install `here` inside the Docker base image

## Testing
- `Rscript` not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6882af4f51cc83309e9168b917f5cfc0