### PR TITLE
Add metadata matching guidance and tidyverse fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,14 @@ The file upload section contains three options. By default, the option "Example"
 - Upload - users can upload HTSeq-count output files, with one file per sample.
 - Select - a placeholder for further development. (e.g.: a dedicated storage folder can be configured to allow users to select files/data if the app is hosted on a server).
 
+
+### 4. Metadata Matching
+
+When using the **Upload** option, the column selected for *File Names* must match the uploaded count file names exactly. The preprocessing step relies on these names to align the metadata with the count matrix. If the names do not correspond (for example, missing extensions or additional spaces), the app will show the message:
+
+```
+Name matching returns count matrix with 0 samples.
+Please make sure the columns of sample names and files names are chosen correctly.
+```
+
+Ensure your metadata lists the same file names (including extensions) as the uploaded files so that each sample is correctly identified.

--- a/helpers.R
+++ b/helpers.R
@@ -183,8 +183,8 @@ htseq_to_mtx <- function(files) {
         df$symbol <- stringr::str_split(df[[gene_col]], pattern = '\\|') %>%
             purrr::map_chr(`[`, 1)
         df <- df %>%
-            dplyr::filter(.data$symbol != '?') %>%
-            dplyr::select(.data$symbol, !!count_col)
+            dplyr::filter(symbol != '?') %>%
+            dplyr::select(symbol, !!count_col)
         names(df)[2] <- 'raw_count'
         df <- df[!duplicated(df$symbol),]
         df$sample <- basename(file_names)[i]
@@ -192,7 +192,7 @@ htseq_to_mtx <- function(files) {
     }
 
     a <- dplyr::bind_rows(df_list) %>%
-        tidyr::pivot_wider(names_from = .data$sample, values_from = .data$raw_count)
+        tidyr::pivot_wider(names_from = sample, values_from = raw_count)
     mtx <- as.matrix(a[,-1])
     rownames(mtx) <- a$symbol
     return(mtx)


### PR DESCRIPTION
## Summary
- clarify metadata file name matching in README
- silence tidyselect warnings in `htseq_to_mtx`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882cd7a8fe083308466e2e75bcf3f92